### PR TITLE
Unpin net-ssh version

### DIFF
--- a/veewee.gemspec
+++ b/veewee.gemspec
@@ -16,10 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "veewee"
 
 
-  # Currently locked to 2.2.0
-  # if specifying to >= 2.2.0 it would use 2.3 and bundler would go in a resolver loop
-  # DEBUG_RESOLVER=1 bundle install
-  s.add_dependency "net-ssh", ">= 2.2.0"
+  s.add_dependency "net-ssh", "~> 2.2.0"
 
   s.add_dependency "mime-types", "~> 1.16"
   s.add_dependency "popen4", "~> 0.1.2"


### PR DESCRIPTION
Apparently there used to be some bundler loop when using newer versions
of net-ssh.  This is no longer the case, however the pinned version does
require a newer ruby version, which we aren't ready to support yet.  So,
fixing this by just unpinning the net-ssh version.
